### PR TITLE
create repo list before running yum-config-manager

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -38,7 +38,8 @@ ENV BASH_ENV=/opt/app-root/etc/scl_enable \
 # Also setup the 'openshift' user that is used for the build execution and for the
 # application runtime execution.
 # TODO: Use better UID and GID values
-RUN yum-config-manager --enable rhel-7-server-optional-rpms && \
+RUN yum repolist > /dev/null && \
+  yum-config-manager --enable rhel-7-server-optional-rpms && \
   INSTALL_PKGS="autoconf \
   automake \
   bsdtar \


### PR DESCRIPTION
per: https://access.redhat.com/solutions/1443553
NOTE: Until the first yum command is run, /etc/yum.repos.d/redhat.repo
contains no repositories, so yum-config-manager will not enable/disable
anything.

fixes #98 