### PR TITLE
Add bzip2 to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   INSTALL_PKGS="autoconf \
   automake \
   bsdtar \
+  bzip2 \
   epel-release \
   findutils \
   gcc-c++ \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -43,6 +43,7 @@ RUN yum repolist > /dev/null && \
   INSTALL_PKGS="autoconf \
   automake \
   bsdtar \
+  bzip2 \
   findutils \
   gcc-c++ \
   gd-devel \


### PR DESCRIPTION
Customer can't use the image, because the bzip2 package is missing.
https://bugzilla.redhat.com/show_bug.cgi?id=1364546
https://github.com/sclorg/s2i-nodejs-container/pull/114